### PR TITLE
Make compatible with Django 3

### DIFF
--- a/{{ cookiecutter.project_name }}/{{ cookiecutter.app_name }}/models.py
+++ b/{{ cookiecutter.project_name }}/{{ cookiecutter.app_name }}/models.py
@@ -2,4 +2,3 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible


### PR DESCRIPTION
Django 3 removed Python 2 support and doesn't include the previously
imported decorator anymore.